### PR TITLE
New distance to similarity calculation

### DIFF
--- a/hestia/similarity.py
+++ b/hestia/similarity.py
@@ -468,8 +468,7 @@ def _embedding_distance(
     df = pd.DataFrame({'queries': queries, 'targets': targets,
                        'metrics': metrics})
     if distance not in ['cosine-np']:
-        max_value = df.metrics.max()
-        df.metrics = df.metrics.map(lambda x: 1 - (x / max_value))
+        df.metrics = df.metrics.map(lambda x: 1 / (1 + x))
     if save_alignment:
         if filename is None:
             filename = time.time()

--- a/tests/test_similarities.py
+++ b/tests/test_similarities.py
@@ -91,7 +91,7 @@ def test_embedding_euclidean_similarity():
     objective_df = pd.DataFrame({
         'queries': [0, 0, 1, 1],
         'targets': [0, 1, 0, 1],
-        'metrics': [1., 0., 0., 1.]
+        'metrics': [1.,  0.440091, 0.440091, 1.]
     })
     assert sim_df.queries.tolist() == objective_df.queries.tolist()
     assert sim_df.targets.tolist() == objective_df.targets.tolist()


### PR DESCRIPTION
- Continuing on addressing issue #14, I have changed the conversion of distances to similarities from d / max(d) to 1 / (1 + d), as it offers a much cleaner alternative, that is always between 0 and 1