### PR TITLE
🪲 Bug fix: RDKit similarities are incompatible with MAPchiral FPs

### DIFF
--- a/hestia/similarity.py
+++ b/hestia/similarity.py
@@ -550,6 +550,10 @@ def _fingerprint_alignment(
                         n_permutations=bits, mapping=False)
             return fp.astype(np.int8)
 
+        if distance in ['dice', 'tanimoto', 'sokal', 'rogot-goldberg',
+                                'cosine']:
+            distance += '-np'
+
     if distance in BULK_SIM_METRICS:
         bulk_sim_metric = BULK_SIM_METRICS[distance]
     else:
@@ -557,8 +561,6 @@ def _fingerprint_alignment(
             f'Distance metric: {distance} not implemented. ' +
             f"Supported metrics: {', '.join(BULK_SIM_METRICS.keys())}"
         )
-    if distance == 'cosine':
-        distance = 'cosine-np'
 
     if (field_name not in df_query.columns):
         raise ValueError(f'{field_name} not found in query DataFrame')

--- a/hestia/utils/__init__.py
+++ b/hestia/utils/__init__.py
@@ -7,9 +7,14 @@ from hestia.utils.graph_part_utils import (_assign_partitions,
 from hestia.utils.label_balance import _balanced_labels
 from hestia.utils.bulk_similarity_metrics import (
     bulk_cosine_similarity, bulk_binary_manhattan_similarity,
-    bulk_binary_euclidean_similarity, bulk_euclidean, bulk_manhattan)
+    bulk_binary_euclidean_similarity, bulk_euclidean, bulk_manhattan,
+    bulk_np_tanimoto, bulk_np_dice, bulk_np_rogot_goldberg, bulk_np_sokal)
 
 BULK_SIM_METRICS = {'cosine-np': bulk_cosine_similarity,
+                    'tanimoto-np': bulk_np_tanimoto,
+                    'dice-np': bulk_np_dice,
+                    'sokal-np': bulk_np_sokal,
+                    'rogot-goldberg-bp': bulk_np_rogot_goldberg,
                     'binary_manhattan': bulk_binary_manhattan_similarity,
                     'binary_euclidean': bulk_binary_euclidean_similarity,
                     'manhattan': bulk_manhattan, 

--- a/hestia/utils/bulk_similarity_metrics.py
+++ b/hestia/utils/bulk_similarity_metrics.py
@@ -3,6 +3,69 @@ from sklearn.metrics.pairwise import (cosine_similarity, manhattan_distances,
                                       euclidean_distances)
 
 
+def bulk_np_tanimoto(u: np.ndarray, bulk: np.ndarray) -> np.ndarray:
+    a = u.sum()
+    out = np.zeros(bulk.shape[0])
+    for i in range(bulk.shape[0]):
+        b = bulk[i].sum()
+        c = ((u + bulk[i]) > 1).sum()
+        denominator = (a + b) - c
+        if denominator == 0:
+            out[i] = 1
+        else:
+            out[i] = c / denominator
+    return out
+
+
+def bulk_np_dice(u: np.ndarray, bulk: np.ndarray) -> np.ndarray:
+    a = u.sum()
+    out = np.zeros(bulk.shape[0])
+    for i in range(bulk.shape[0]):
+        b = bulk[i].sum()
+        c = ((u + bulk[i]) > 1).sum()
+        denominator = a + b
+        if denominator == 0:
+            out[i] = 1
+        else:
+            out[i] = (2 * c) / denominator
+    return out
+
+
+def bulk_np_sokal(u: np.ndarray, bulk: np.ndarray) -> np.ndarray:
+    a = u.sum()
+    out = np.zeros(bulk.shape[0])
+    for i in range(bulk.shape[0]):
+        b = bulk[i].sum()
+        c = ((u + bulk[i]) > 1).sum()
+        denominator = 2 * (a + b) - 3 * c
+        if denominator == 0:
+            out[i] = 1
+        else:
+            out[i] = c / denominator
+    return out
+
+
+def bulk_np_rogot_goldberg(u: np.ndarray, bulk: np.ndarray) -> np.ndarray:
+    a = u.sum()
+    e = bulk.shape[1]
+    out = np.zeros(bulk.shape[0])
+
+    for i in range(bulk.shape[0]):
+        b = bulk[i].sum()
+        c = np.dot(u, bulk[i])
+        d = e + c - (a + b)
+
+        denominator_1 = a + b
+        denominator_2 = 2 * e - (a + b)
+        if a == e or d == e:
+            out[i] = 1
+        elif denominator_1 == 0 or denominator_2 == 0:
+            out[i] = 0
+        else:
+            out[i] = c / denominator_1 - d / denominator_2
+    return out
+
+
 def bulk_cosine_similarity(u: np.ndarray, bulk: np.ndarray) -> np.ndarray:
     out = np.zeros(bulk.shape[0])
     for i in range(bulk.shape[0]):

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/IBM/Hestia-OOD',
-    version='0.0.21',
+    version='0.0.22',
     zip_safe=False,
 )


### PR DESCRIPTION
Implemented new bulk similarities following the RDKit code, but in Python with Numpy. They are less efficient as discussed in  #19, but they are the only current solution.