### PR TITLE
🪲 Bug fixes: MAP4 is not a binary FP and Tanimoto is no longer the unique similarity for molecules

### DIFF
--- a/hestia/dataset_generator.py
+++ b/hestia/dataset_generator.py
@@ -141,7 +141,6 @@ class SimilarityArguments:
         self.needle_config = needle_config
 
         if self.data_type == 'small_molecule':
-            self.distance = 'tanimoto'
             self.bits = 1_022
             self.radius = radius
         elif self.data_type == 'protein':

--- a/hestia/similarity.py
+++ b/hestia/similarity.py
@@ -547,12 +547,12 @@ def _fingerprint_alignment(
         def _get_fp(smile: str):
             mol = Chem.MolFromSmiles(smile)
             fp = encode(mol, max_radius=radius,
-                        n_permutations=bits, mapping=False)
-            return fp.astype(np.int8)
+                            n_permutations=bits, mapping=False)
+            return fp
 
-        if distance in ['dice', 'tanimoto', 'sokal', 'rogot-goldberg',
-                                'cosine']:
-            distance += '-np'
+        if distance != 'jaccard':
+            print(distance)
+            raise ValueError('MAP4 can only be used with `jaccard`.')
 
     if distance in BULK_SIM_METRICS:
         bulk_sim_metric = BULK_SIM_METRICS[distance]
@@ -618,6 +618,7 @@ def _fingerprint_alignment(
                     metrics.append(metric)
 
     df = pd.DataFrame({'query': queries, 'target': targets, 'metric': metrics})
+    print(df)
     if save_alignment:
         if filename is None:
             filename = time.time()

--- a/hestia/utils/__init__.py
+++ b/hestia/utils/__init__.py
@@ -8,14 +8,18 @@ from hestia.utils.label_balance import _balanced_labels
 from hestia.utils.bulk_similarity_metrics import (
     bulk_cosine_similarity, bulk_binary_manhattan_similarity,
     bulk_binary_euclidean_similarity, bulk_euclidean, bulk_manhattan,
-    bulk_np_tanimoto, bulk_np_dice, bulk_np_rogot_goldberg, bulk_np_sokal)
+    bulk_np_tanimoto, bulk_np_dice, bulk_np_rogot_goldberg, bulk_np_sokal,
+    bulk_np_jaccard)
 
-BULK_SIM_METRICS = {'cosine-np': bulk_cosine_similarity,
-                    'tanimoto-np': bulk_np_tanimoto,
-                    'dice-np': bulk_np_dice,
-                    'sokal-np': bulk_np_sokal,
-                    'rogot-goldberg-bp': bulk_np_rogot_goldberg,
-                    'binary_manhattan': bulk_binary_manhattan_similarity,
-                    'binary_euclidean': bulk_binary_euclidean_similarity,
-                    'manhattan': bulk_manhattan, 
-                    'euclidean': bulk_euclidean}
+BULK_SIM_METRICS = {
+    'cosine-np': bulk_cosine_similarity,
+    'tanimoto-np': bulk_np_tanimoto,
+    'dice-np': bulk_np_dice,
+    'sokal-np': bulk_np_sokal,
+    'rogot-goldberg-bp': bulk_np_rogot_goldberg,
+    'binary_manhattan': bulk_binary_manhattan_similarity,
+    'binary_euclidean': bulk_binary_euclidean_similarity,
+    'jaccard': bulk_np_jaccard,
+    'manhattan': bulk_manhattan,
+    'euclidean': bulk_euclidean
+}

--- a/hestia/utils/bulk_similarity_metrics.py
+++ b/hestia/utils/bulk_similarity_metrics.py
@@ -3,13 +3,23 @@ from sklearn.metrics.pairwise import (cosine_similarity, manhattan_distances,
                                       euclidean_distances)
 
 
+def bulk_np_jaccard(u: np.ndarray, bulk: np.ndarray) -> np.ndarray:
+    out = np.zeros(bulk.shape[0])
+    bits = bulk.shape[1]
+    for i in range(bulk.shape[0]):
+        out[i] = (u == bulk[i]).sum() / bits
+    return out
+
+
 def bulk_np_tanimoto(u: np.ndarray, bulk: np.ndarray) -> np.ndarray:
     a = u.sum()
     out = np.zeros(bulk.shape[0])
     for i in range(bulk.shape[0]):
         b = bulk[i].sum()
-        c = ((u + bulk[i]) > 1).sum()
+        c = np.dot(u, bulk[i])
         denominator = (a + b) - c
+        if denominator == 0:
+            print(a, b, c)
         if denominator == 0:
             out[i] = 1
         else:
@@ -22,7 +32,7 @@ def bulk_np_dice(u: np.ndarray, bulk: np.ndarray) -> np.ndarray:
     out = np.zeros(bulk.shape[0])
     for i in range(bulk.shape[0]):
         b = bulk[i].sum()
-        c = ((u + bulk[i]) > 1).sum()
+        c = np.dot(u, bulk[i])
         denominator = a + b
         if denominator == 0:
             out[i] = 1
@@ -36,7 +46,7 @@ def bulk_np_sokal(u: np.ndarray, bulk: np.ndarray) -> np.ndarray:
     out = np.zeros(bulk.shape[0])
     for i in range(bulk.shape[0]):
         b = bulk[i].sum()
-        c = ((u + bulk[i]) > 1).sum()
+        c = np.dot(u, bulk[i])
         denominator = 2 * (a + b) - 3 * c
         if denominator == 0:
             out[i] = 1

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/IBM/Hestia-OOD',
-    version='0.0.22',
+    version='0.0.23',
     zip_safe=False,
 )

--- a/tests/test_similarities.py
+++ b/tests/test_similarities.py
@@ -109,15 +109,16 @@ def test_mapchiral():
     sim_df = calculate_similarity(
         df, data_type='small_molecule',
         similarity_metric='map4',
-        distance='cosine-np',
+        distance='jaccard',
         field_name='smiles',
         threshold=0.
     )
     objective_df = pd.DataFrame({
         'query': [0, 0, 0, 1, 1, 1, 2, 2, 2],
         'target': [0, 1, 2, 0, 1, 2, 0, 1, 2],
-        'metric': [1., 0.593769, 0.033267, 0.593769, 1.,
-                   0.067812, 0.033267, 0.067812, 1.]
+        'metric': [1.0, 0.5634765625, 0.0390625,
+                   0.5634765625, 1.0, 0.0302734375,
+                   0.0390625, 0.0302734375, 1.0]
     })
     assert sim_df['query'].tolist() == objective_df['query'].tolist()
     assert sim_df['target'].tolist() == objective_df['target'].tolist()


### PR DESCRIPTION
- 🪲 Bug fix 1: MAP4 is not a binary FP. This required implementing a non-binary jaccard similarity metric specific to MAP4 fingerprints. As a way to avoid user errors, the program checks what distance is being used with MAP4 and only allows `jaccard`.
- 🪲 Bug fix 2: Similarity arguments class was overwriting the values of distance and substituting them with `tanimoto`, this was a functionality to wrong inputs from where `tanimoto` was the only similarity metric allowed between molecular fingeprints.